### PR TITLE
typo: updated spec name

### DIFF
--- a/test/HTTPSpec.hs
+++ b/test/HTTPSpec.hs
@@ -14,5 +14,5 @@ spec = do
         get "/" `shouldRespondWith` 200
 
     with (return $ app $ return (False, "hello")) $ do
-      it "return 412 on failure" $ do
+      it "return 500 on failure" $ do
         get "/" `shouldRespondWith` 500


### PR DESCRIPTION
(I guess a `500` is needed to make curl throw a non-zero exit-code.)