### PR TITLE
Make hasSpec tolerate more ghci settings.

### DIFF
--- a/src/Session.hs
+++ b/src/Session.hs
@@ -13,6 +13,7 @@ module Session (
 , runSpec
 , hspecPreviousSummary
 , resetSummary
+, parseSummary
 ) where
 
 import           Data.IORef

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -70,9 +70,8 @@ hspecCommand = "Test.Hspec.Runner.hspecResult spec"
 hasSpec :: Session -> IO Bool
 hasSpec Session{..} = do
   xs <- normalizeTypeSignatures <$> eval sessionInterpreter (":type " ++ hspecCommand)
-  case lines xs of
-    [ys] -> return $ (hspecCommand ++ " :: IO ") `isPrefixOf` ys && "Summary" `isSuffixOf` ys
-    _ -> return False
+  let match line = (hspecCommand ++ " :: IO ") `isPrefixOf` line && "Summary" `isSuffixOf` line
+  return . any match . lines $ xs
 
 runSpec :: Session -> IO String
 runSpec session@Session{..} = do

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -10,6 +10,7 @@ module Session (
 , isFailure
 , isSuccess
 , hasSpec
+, hasSpecString
 , runSpec
 , hspecPreviousSummary
 , resetSummary

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -70,10 +70,14 @@ hspecCommand :: String
 hspecCommand = "Test.Hspec.Runner.hspecResult spec"
 
 hasSpec :: Session -> IO Bool
-hasSpec Session{..} = do
-  xs <- normalizeTypeSignatures <$> eval sessionInterpreter (":type " ++ hspecCommand)
-  let match line = (hspecCommand ++ " :: IO ") `isPrefixOf` line && "Summary" `isSuffixOf` line
-  return . any match . lines $ xs
+hasSpec Session{..} =
+  hasSpecString . normalizeTypeSignatures <$> eval sessionInterpreter (":type " ++ hspecCommand)
+
+hasSpecString :: String -> Bool
+hasSpecString = any match . lines
+  where
+    match line = (hspecCommand ++ " :: IO ") `isPrefixOf` line
+              && "Summary" `isSuffixOf` line
 
 runSpec :: Session -> IO String
 runSpec session@Session{..} = do

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -17,6 +17,7 @@ module Session (
 
 import           Data.IORef
 import           Data.List.Compat
+import           Data.Maybe (listToMaybe, catMaybes)
 import           Prelude ()
 import           Prelude.Compat
 import           Text.Read.Compat
@@ -91,10 +92,10 @@ isSuccess :: Maybe Summary -> Bool
 isSuccess = not . isFailure
 
 parseSummary :: String -> Maybe Summary
-parseSummary r = case reverse $ lines r of
-  x : _ -> readMaybe (dropAnsiEscapeSequences x)
-  [] -> Nothing
+parseSummary = findJust . (map $ readMaybe . dropAnsiEscapeSequences) . take 3 . reverse . lines
   where
+    findJust = listToMaybe . catMaybes
+
     dropAnsiEscapeSequences xs
       | "Summary" `isPrefixOf` xs = xs
       | otherwise = case xs of

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -98,7 +98,7 @@ isSuccess :: Maybe Summary -> Bool
 isSuccess = not . isFailure
 
 parseSummary :: String -> Maybe Summary
-parseSummary = findJust . (map $ readMaybe . dropAnsiEscapeSequences) . take 3 . reverse . lines
+parseSummary = findJust . (map $ readMaybe . dropAnsiEscapeSequences) . reverse . lines
   where
     findJust = listToMaybe . catMaybes
 

--- a/test/SessionSpec.hs
+++ b/test/SessionSpec.hs
@@ -71,7 +71,7 @@ spec = do
     it "takes a rendering of a summary and returns the parse result" $ do
       Session.parseSummary "Summary {summaryExamples = 2, summaryFailures = 0}" `shouldBe` Just (Summary 2 0)
 
-    it "can find the summary in the last 3 lines of a multi-line input" $ do
+    it "can find the summary anywere in a multi-line input" $ do
       Session.parseSummary "\n...\n...\nSummary {summaryExamples = 2, summaryFailures = 0}" `shouldBe` Just (Summary 2 0)
       Session.parseSummary "...\n...\nSummary {summaryExamples = 2, summaryFailures = 0}\n" `shouldBe` Just (Summary 2 0)
       Session.parseSummary "...\nSummary {summaryExamples = 2, summaryFailures = 0}\n...\n" `shouldBe` Just (Summary 2 0)
@@ -79,6 +79,3 @@ spec = do
 
     it "can find Summary at the middle of a line, after noise (to cope with ansi escapes)" $ do
       Session.parseSummary "noiseSummary {summaryExamples = 2, summaryFailures = 0}" `shouldBe` Just (Summary 2 0)
-
-    it "does NOT find the summary in earlier lines of a multi-line input" $ do
-      Session.parseSummary "Summary {summaryExamples = 2, summaryFailures = 0}\n...\n...\n...\n" `shouldBe` Nothing

--- a/test/SessionSpec.hs
+++ b/test/SessionSpec.hs
@@ -37,6 +37,25 @@ spec = do
           _ <- silence (Session.reload session)
           Session.hasSpec session `shouldReturn` False
 
+  describe "hasSpecString" $ do
+    let sample i b e = unlines
+          [ "..."
+          , b ++ "Test.Hspec.Runner.hspecResult spec :: IO " ++ i ++ "Summary" ++ e
+          , "..."
+          ]
+
+    context "when module contains spec" $ do
+      it "returns True" $ do
+        Session.hasSpecString (sample "" "" "") `shouldBe` True
+        Session.hasSpecString (sample "oriy" "" "") `shouldBe` True
+        Session.hasSpecString (sample "..........................." "" "") `shouldBe` True
+
+    context "when module does not contain spec" $ do
+      it "returns False" $ do
+        Session.hasSpecString "..." `shouldBe` False
+        Session.hasSpecString (sample "" ".." "") `shouldBe` False
+        Session.hasSpecString (sample "oriy" "" "<<") `shouldBe` False
+
   describe "runSpec" $ around_ withSomeSpec $ do
     it "stores summary of spec run" $ do
       withSession ["Spec.hs"] $ \session -> do


### PR DESCRIPTION
If you have something like `:set +m +t` in your global .ghci file, hasSpec will get confused by the more verbose output.  This change matches against all lines of the output until it succeeds.

If you think this change is too hacky, I'd be interested if you have another idea.