### PR TITLE
Ignore changes to emacs auto-save files.

### DIFF
--- a/src/Util.hs
+++ b/src/Util.hs
@@ -18,9 +18,10 @@ withInfoColor = bracket_ set reset
     reset = setSGR []
 
 isBoring :: FilePath -> Bool
-isBoring p = ".git" `elem` dirs || "dist" `elem` dirs
+isBoring p = ".git" `elem` dirs || "dist" `elem` dirs || isEmacsAutoSave p
   where
     dirs = splitDirectories p
+    isEmacsAutoSave = isPrefixOf ".#" . takeBaseName
 
 normalizeTypeSignatures :: String -> String
 normalizeTypeSignatures = \case

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -21,7 +21,7 @@ isBoring :: FilePath -> Bool
 isBoring p = ".git" `elem` dirs || "dist" `elem` dirs || isEmacsAutoSave p
   where
     dirs = splitDirectories p
-    isEmacsAutoSave = isPrefixOf ".#" . takeBaseName
+    isEmacsAutoSave = isPrefixOf ".#" . takeFileName
 
 normalizeTypeSignatures :: String -> String
 normalizeTypeSignatures = \case


### PR DESCRIPTION
I guess there should be a .boring.sensei file eventually, but I thought this may be relevant enough (there are people using emacs out there!) and robust enough to have a chance to make it to master.  (-:

(Come to think of it: would it be a good idea to honor .boring and .gitignore whenever they are present?)