### PR TITLE
Adding a couple of options for sensei

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /dist/
+.stack-work/
+*.hi
+*.i_hi
+*.o
+*.i_o

--- a/driver/sensei-web.hs
+++ b/driver/sensei-web.hs
@@ -1,8 +1,7 @@
 module Main (main) where
 
-import           System.Environment
-
+import           Options
 import           Run
 
 main :: IO ()
-main = getArgs >>= runWeb
+main = withArgs runWeb

--- a/driver/sensei.hs
+++ b/driver/sensei.hs
@@ -1,8 +1,8 @@
 module Main (main) where
 
-import           System.Environment
 
+import           Options
 import           Run
 
 main :: IO ()
-main = getArgs >>= run
+main = withArgs run

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,8 @@ dependencies:
   - bytestring
   - filepath
   - unix
+  - optparse-applicative
+  - regex-tdfa
 
 ghc-options: -Wall
 

--- a/sensei.cabal
+++ b/sensei.cabal
@@ -43,6 +43,8 @@ executable seito
     , bytestring
     , filepath
     , unix
+    , optparse-applicative
+    , regex-tdfa
   other-modules:
       Client
       EventQueue
@@ -80,6 +82,8 @@ executable sensei
     , bytestring
     , filepath
     , unix
+    , optparse-applicative
+    , regex-tdfa
   other-modules:
       Client
       EventQueue
@@ -117,6 +121,8 @@ executable sensei-web
     , bytestring
     , filepath
     , unix
+    , optparse-applicative
+    , regex-tdfa
   other-modules:
       Client
       EventQueue
@@ -155,6 +161,8 @@ test-suite spec
     , bytestring
     , filepath
     , unix
+    , optparse-applicative
+    , regex-tdfa
     , hspec >= 2.2.1
     , hspec-wai
     , mockery

--- a/src/Client.hs
+++ b/src/Client.hs
@@ -1,20 +1,22 @@
-{-# LANGUAGE RecordWildCards, OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 module Client (client) where
 
-import           Prelude ()
-import           Prelude.Compat
-import           Control.Monad.Compat
 import           Control.Exception
+import           Control.Monad.Compat
+import qualified Data.ByteString.Lazy         as L
 import           Data.String
-import           System.IO.Error
 import           Network.HTTP.Client
 import           Network.HTTP.Client.Internal
 import           Network.HTTP.Types
-import           Network.Socket hiding (recv)
-import           Network.Socket.ByteString (sendAll, recv)
-import qualified Data.ByteString.Lazy as L
+import           Network.Socket               hiding (recv)
+import           Network.Socket.ByteString    (recv, sendAll)
+import           Prelude                      ()
+import           Prelude.Compat
+import           System.IO.Error
 
-import           HTTP (newSocket, socketAddr, socketName)
+import           HTTP                         (newSocket, socketAddr,
+                                               socketName)
 
 client :: IO (Bool, L.ByteString)
 client = either (const $ connectError) id <$> tryJust p go

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE OverloadedStrings, LambdaCase #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Util where
 
-import           Prelude ()
+import           Prelude                ()
 import           Prelude.Compat
 
 import           Control.Exception
@@ -10,6 +11,8 @@ import           System.Console.ANSI
 import           System.FilePath
 import           System.Posix.Files
 import           System.Posix.Types
+import           Text.Regex.TDFA        ((=~))
+import           Text.Regex.TDFA.String ()
 
 withInfoColor :: IO a -> IO a
 withInfoColor = bracket_ set reset
@@ -22,6 +25,9 @@ isBoring p = ".git" `elem` dirs || "dist" `elem` dirs || isEmacsAutoSave p
   where
     dirs = splitDirectories p
     isEmacsAutoSave = isPrefixOf ".#" . takeFileName
+
+allIntresting :: String -> FilePath -> Bool
+allIntresting regex p = (p =~ regex) && (not $ isBoring p)
 
 normalizeTypeSignatures :: String -> String
 normalizeTypeSignatures = normalize . concatMap replace

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-5.8
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/test/Helper.hs
+++ b/test/Helper.hs
@@ -1,10 +1,13 @@
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE QuasiQuotes     #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module Helper (
   module Test.Hspec
 , module Test.Mockery.Directory
 , module Control.Applicative
 , module System.IO.Silently
 , withSession
+, withSenseiSession
 , withSomeSpec
 , passingSpec
 , failingSpec
@@ -17,15 +20,19 @@ import           System.IO.Silently
 import           Test.Hspec
 import           Test.Mockery.Directory
 
-import           Run ()
+import           Options
+import           Run                     ()
+import           Session                 (Session)
 import qualified Session
-import           Session (Session)
 
 withSession :: [String] -> (Session -> IO a) -> IO a
-withSession args action = bracket (Session.new $ "-ignore-dot-ghci" : args) Session.close action
+withSession args action = bracket (Session.new $ SenseiArgs "^*$" True ("-ignore-dot-ghci" : args)) Session.close action
 
 withSomeSpec :: IO a -> IO a
 withSomeSpec = (inTempDirectory .  (writeFile "Spec.hs" passingSpec >>))
+
+withSenseiSession :: SenseiArgs -> (Session -> IO a) -> IO a
+withSenseiSession SenseiArgs{..} action = bracket (Session.new $ SenseiArgs watch testFlag ("-ignore-dot-ghci" : otherArgs)) Session.close action
 
 passingSpec :: String
 passingSpec = [i|

--- a/test/TriggerSpec.hs
+++ b/test/TriggerSpec.hs
@@ -1,10 +1,10 @@
 module TriggerSpec (spec) where
 
-import           Helper
 import           Data.List
+import           Helper
 
+import           Options   (SenseiArgs (..))
 import           Trigger
-
 normalize :: String -> [String]
 normalize = normalizeErrors . normalizeTiming . normalizeSeed . lines
   where
@@ -113,7 +113,7 @@ spec = do
           writeFile "Spec.hs" passingSpec
           (True, xs) <- silence (trigger session)
           normalize xs `shouldBe` [
-              "[1 of 1] Compiling Spec             ( Spec.hs, interpreted )"
+            "[1 of 1] Compiling Spec             ( Spec.hs, interpreted )"
             , "Ok, modules loaded: Spec."
             , ""
             , "bar"
@@ -135,3 +135,9 @@ spec = do
         withSession ["Spec.hs"] $ \session -> do
           writeFile "Spec.hs" "module Main where"
           silence (trigger session >> trigger session) `shouldReturn` (True, "Ok, modules loaded: Main.\n")
+
+    context "with only-compile flag on, should not run tests" $ do
+      it "only reloads" $ do
+        withSenseiSession (SenseiArgs "^*$" False ["Spec.hs"]) $ \session -> do
+          writeFile "Spec.hs" passingSpec
+          silence (trigger session >> trigger session) `shouldReturn` (True, "Ok, modules loaded: Spec.\n")

--- a/test/UtilSpec.hs
+++ b/test/UtilSpec.hs
@@ -17,6 +17,19 @@ spec = do
     it "ignores files in dist/" $ do
       isBoring "/foo/bar/dist/baz/foo.txt" `shouldBe` True
 
+  describe "isIntresting" $ do
+    it "ignores files in .git/" $ do
+      allIntresting "^*$" "/foo/bar/.git/baz/foo.txt" `shouldBe` False
+
+    it "ignores filepaths which doesn't match regex" $ do
+      allIntresting "^*.hs$" "/foo/bar/baz/foo.txt" `shouldBe` False
+
+    it "dones't ignore matching and not boring filepaths" $ do
+      allIntresting "^*.hs$" "/foo/bar/baz/foo.hs" `shouldBe` True
+
+
+
+
   describe "normalizeTypeSignatures" $ do
     it "removes newlines from type signatures" $ do
       normalizeTypeSignatures "foo\n  :: Int" `shouldBe` "foo :: Int"

--- a/test/UtilSpec.hs
+++ b/test/UtilSpec.hs
@@ -27,9 +27,6 @@ spec = do
     it "dones't ignore matching and not boring filepaths" $ do
       allIntresting "^*.hs$" "/foo/bar/baz/foo.hs" `shouldBe` True
 
-
-
-
   describe "normalizeTypeSignatures" $ do
     it "removes newlines from type signatures" $ do
       normalizeTypeSignatures "foo\n  :: Int" `shouldBe` "foo :: Int"


### PR DESCRIPTION
1.  added `(-w | --watch "PATTERN")` option which accepts a pattern to which files to be looked for. 
2.  added a (rather controversial ;)) "compile-only" flag, which won't run tests but just do a reload. This is to avail an option to not run time consuming tests but still want to use Sensei for auto-compilation. Although this could be achieved previously by passing a module which doesn't contain a `spec`, but I thought it would be better be an explicit command line flag.

Currently command line help looks like:

```
Usage: sensei [-w|--watch PATTERN] [-c|--only-compile]
              [-- ARGS (ghci or hspec args)]
  Automatically compile and run Hspec tests on file modifications

Available options:
  -h,--help                Show this help text
  -w,--watch PATTERN       regex to what files to include in watching the
                           directory
  -c,--only-compile        Only compile, no tests run!
```

@sol WDYT?
