### PR TITLE
Add -XNoOverloadedStrings to the wrong place.

### DIFF
--- a/src/Session.hs
+++ b/src/Session.hs
@@ -56,6 +56,7 @@ new args = do
   let (ghciArgs, hspecArgs) = splitArgs args
   ghci <- GhciWrapper.new defaultConfig{configVerbose = True, configIgnoreDotGhci = False} ghciArgs
   _ <- eval ghci (":set prompt " ++ show "")
+  _ <- eval ghci ":set -XNoOverloadedStrings"
   _ <- eval ghci ("import qualified System.Environment")
   _ <- eval ghci ("import qualified Test.Hspec.Runner")
   _ <- eval ghci ("import qualified Test.Hspec.Meta")


### PR DESCRIPTION
This is more of a request for ideas rather than a request for merging.  It solves my problem, but I'm happy to work on it more in order to get it merged.

The symptom: I have `:set -XOverloadedStrings` in my .ghci, and sensei pulls it and makes some noise about ambiguous string types in `<interactive>`.

The work-around: See my commit.  This doesn't turn off overloaded strings immediately, but after the first test run, it has done its thing and the output is not cluttered any more.

Please let me know if there is a chance of getting a similar (or wildly different) solution accepted.  For example, we could just add some type signatures to the offending command lines, but I've been to impatient to find them.
