### PR TITLE
Drain `stdout` of `ghci` process on shutdown

### DIFF
--- a/src/Imports.hs
+++ b/src/Imports.hs
@@ -1,9 +1,10 @@
 module Imports (module Imports) where
 
-import           Control.Arrow as Imports ((>>>))
+import           Control.Arrow as Imports ((>>>), (&&&))
 import           Control.Concurrent as Imports
 import           Control.Exception as Imports
 import           Control.Monad as Imports
+import           Data.Functor as Imports
 import           Data.Bifunctor as Imports
 import           Data.Char as Imports
 import           Data.List as Imports
@@ -17,3 +18,12 @@ import           Text.Read as Imports (readMaybe)
 
 pass :: Applicative m => m ()
 pass = pure ()
+
+while :: Monad m => m Bool -> m () -> m ()
+while p action = go
+  where
+    go = do
+      notDone <- p
+      when notDone $ do
+        action
+        go

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -57,7 +57,7 @@ withSession config args action = do
     (ghciArgs, hspecArgs) = splitArgs args
 
 reload :: Session -> IO String
-reload Session{..} = evalEcho sessionInterpreter ":reload"
+reload Session{..} = evalVerbose sessionInterpreter ":reload"
 
 data Summary = Summary {
   summaryExamples :: Int
@@ -96,7 +96,7 @@ runSpec :: String -> Session -> IO String
 runSpec command session@Session{..} = do
   failedPreviously <- isFailure <$> hspecPreviousSummary session
   let args = "--color" : (if failedPreviously then addRerun else id) sessionHspecArgs
-  r <- evalEcho sessionInterpreter $ "System.Environment.withArgs " ++ show args ++ " $ " ++ command
+  r <- evalVerbose sessionInterpreter $ "System.Environment.withArgs " ++ show args ++ " $ " ++ command
   writeIORef sessionHspecPreviousSummary (parseSummary r)
   return r
   where

--- a/test/Language/Haskell/GhciWrapperSpec.hs
+++ b/test/Language/Haskell/GhciWrapperSpec.hs
@@ -3,7 +3,7 @@ module Language.Haskell.GhciWrapperSpec (main, spec) where
 
 import           Helper
 
-import           Language.Haskell.GhciWrapper (Interpreter)
+import           Language.Haskell.GhciWrapper (Config(..), Interpreter)
 import qualified Language.Haskell.GhciWrapper as Interpreter
 
 main :: IO ()
@@ -17,6 +17,13 @@ withGhci action = withInterpreter [] $ action . Interpreter.eval
 
 spec :: Spec
 spec = do
+  describe "withInterpreter" $ do
+    context "on shutdown" $ do
+      it "drains `stdout` of the `ghci` process" $ do
+        result <- capture_ $ Interpreter.withInterpreter ghciConfig {configVerbose = True} [] $ \ _ghci -> do
+          pass
+        last (lines result) `shouldBe` "Leaving GHCi."
+
   describe "evalVerbose" $ do
     it "echos result to stdout" $ do
       withInterpreter [] $ \ ghci -> do

--- a/test/Language/Haskell/GhciWrapperSpec.hs
+++ b/test/Language/Haskell/GhciWrapperSpec.hs
@@ -17,10 +17,10 @@ withGhci action = withInterpreter [] $ action . Interpreter.eval
 
 spec :: Spec
 spec = do
-  describe "evalEcho" $ do
-    it "prints result to stdout" $ do
+  describe "evalVerbose" $ do
+    it "echos result to stdout" $ do
       withInterpreter [] $ \ ghci -> do
-        capture (Interpreter.evalEcho ghci $ "putStr" ++ show "foo\nbar") `shouldReturn` ("foo\nbar", "foo\nbar")
+        capture (Interpreter.evalVerbose ghci $ "putStr" ++ show "foo\nbar") `shouldReturn` ("foo\nbar", "foo\nbar")
 
   describe "eval" $ do
     it "shows literals" $ withGhci $ \ ghci -> do

--- a/test/ReadHandleSpec.hs
+++ b/test/ReadHandleSpec.hs
@@ -38,6 +38,11 @@ partialMarker = B.take 5 marker
 
 spec :: Spec
 spec = do
+  describe "drain" $ do
+    it "drains all remaining input" $ do
+      h <- fakeHandle ["foo", marker, "bar", marker, "baz", marker, ""]
+      withSpy (drain h) `shouldReturn` ["foo", "bar", "baz"]
+
   describe "getResult" $ do
     context "with a single result" $ do
       let input = ["foo", "bar", "baz", marker]


### PR DESCRIPTION
This way colors / cursor will be reset on ctrl-c during a test run.