### PR TITLE
increase input delay

### DIFF
--- a/src/Input.hs
+++ b/src/Input.hs
@@ -20,7 +20,7 @@ forEachInputChar handle action = do
     chunkSize = 64
 
     inputDelay :: Int
-    inputDelay = 1_000
+    inputDelay = 100_000
 
     go :: IO ()
     go = B.hGetNonBlocking handle chunkSize >>= \ case


### PR DESCRIPTION
With an input delay of 0.1s sensei causes negligible CPU load, and still feels reasonably responsive