### PR TITLE
pager jumps to ghc's module import cycle error message

### DIFF
--- a/src/Pager.hs
+++ b/src/Pager.hs
@@ -18,4 +18,9 @@ pager input = do
     readMVar pid >>= terminateProcess
     void $ wait tid
   where
-    less = proc "less" ["--RAW", "--QUIT-AT-EOF", "--pattern", "^.*\\w:\\d+:\\d+:.+$"]
+    less = proc "less" ["--RAW", "--QUIT-AT-EOF", "--pattern", pattern]
+    patterns =
+      [ "^.*\\w:\\d+:\\d+:.+$"
+      , "^Module imports form a cycle:$"
+      ]
+    pattern = intercalate "|" patterns


### PR DESCRIPTION
Support detecting the error message "Module imports form a cycle:"