### PR TITLE
pager: Match arbitrary input as a fallback

### DIFF
--- a/sensei.cabal
+++ b/sensei.cabal
@@ -220,6 +220,7 @@ test-suite spec
       HTTPSpec
       Language.Haskell.GhciWrapperSpec
       OptionsSpec
+      PagerSpec
       ReadHandleSpec
       RunSpec
       SessionSpec

--- a/src/Pager.hs
+++ b/src/Pager.hs
@@ -18,9 +18,7 @@ pager input = do
     readMVar pid >>= terminateProcess
     void $ wait tid
   where
-    less = proc "less" ["--RAW", "--QUIT-AT-EOF", "--pattern", pattern]
-    patterns =
-      [ "^.*\\w:\\d+:\\d+:.+$"
-      , "^Module imports form a cycle:$"
-      ]
-    pattern = intercalate "|" patterns
+    less = proc "less" $ "--RAW" : "--QUIT-AT-EOF" : matchOptions
+
+matchOptions :: [String]
+matchOptions = ["--incsearch", "--pattern", "^.*\\w:\\d+:\\d+:.+$|"]

--- a/test/PagerSpec.hs
+++ b/test/PagerSpec.hs
@@ -1,0 +1,15 @@
+module PagerSpec (spec) where
+
+import           Helper
+
+import           Pager
+
+spec :: Spec
+spec = do
+  describe "matchOptions" $ do
+    it "contains --incsearch" $ do
+      -- The `--incsearch` flag changes the behavior of `--pattern` in subtle
+      -- ways.  A user might have `--incsearch` enabled globally.  To ensure
+      -- consistent behavior across environments we always enable
+      -- `--incsearch`.
+      matchOptions `shouldContain` ["--incsearch"]


### PR DESCRIPTION
This is useful e.g.:

- on cyclic imports (the actual format varies across GHC versions)
- when you specify invalid command line options