### PR TITLE
Allow to freely intermix GHC flags and Hspec options on the command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ additional GHC options on the command line:
 
     sensei -isrc -itest test/Spec.hs
 
-Command-line arguments that look like Hspec options are passed to Hspec.  To
-avoid ambiguity, GHC options have to be given before any Hspec options:
+Command-line arguments that look like Hspec options are passed to Hspec:
 
     sensei -isrc -itest test/Spec.hs --no-color --match foo
 
-All command-line arguments after the last `--` are passed to Hspec, regardless
-of how they look:
+Hspec's `-f` option collides with GHC flags.  To avoid ambiguity, `sensei` does
+not accept Hspec's `-f` option.  Use `--format` instead:
+
+    sensei -isrc -itest test/Spec.hs --format progress -fdiagnostics-as-json
+
+A `--` disables any command-line processing.  All command-line arguments after
+the last `--` are unconditionally passed to Hspec:
 
     sensei -isrc -itest test/Spec.hs -- --no-color --match foo
 

--- a/test/Language/Haskell/GhciWrapperSpec.hs
+++ b/test/Language/Haskell/GhciWrapperSpec.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-module Language.Haskell.GhciWrapperSpec (main, spec) where
+module Language.Haskell.GhciWrapperSpec (spec) where
 
 import           Helper hiding (diagnostic, ghciConfig)
 import qualified Helper
@@ -8,9 +8,6 @@ import qualified Data.ByteString.Char8 as ByteString
 
 import           Language.Haskell.GhciWrapper (Config(..), Interpreter(..), ReloadStatus(..), Extract(..))
 import qualified Language.Haskell.GhciWrapper as Interpreter
-
-main :: IO ()
-main = hspec spec
 
 withInterpreter :: [String] -> (Interpreter -> IO a) -> IO a
 withInterpreter args action = do

--- a/test/OptionsSpec.hs
+++ b/test/OptionsSpec.hs
@@ -1,27 +1,29 @@
-module OptionsSpec (main, spec) where
+module OptionsSpec (spec) where
 
 import           Helper
 
 import           Options
 
-main :: IO ()
-main = hspec spec
-
 spec :: Spec
 spec = do
-  describe "splitArgs" $ do
-    it "returns longest matching list of Hspec options from end of given list" $ do
-      splitArgs ["foo", "--bar", "-m", "FooSpec", "-a", "1000"] `shouldBe` (["foo", "--bar"], ["-m", "FooSpec", "-a", "1000"])
+  describe "splitArgs" do
+    it "passes command-line arguments that look like Hspec options to Hspec" do
+      splitArgs ["foo", "-m", "FooSpec", "--bar", "-a", "1000"] `shouldBe`
+        (["foo", "--bar"], ["-m", "FooSpec", "-a", "1000"])
 
-    it "assumes everything after the last '--' to be Hspec options" $ do
+    it "passes -f options to GHC" do
+      splitArgs ["--format", "checks", "-fno-diagnostics-as-json"] `shouldBe`
+        (["-fno-diagnostics-as-json"], ["--format", "checks"])
+
+    it "assumes everything after the last '--' to be Hspec options" do
       splitArgs ["foo", "bar", "--", "foo", "baz"] `shouldBe` (["foo", "bar"], ["foo", "baz"])
 
-    context "with -p" $ do
-      it "recognizes -p as an Hspec option" $ do
+    context "with -p" do
+      it "recognizes -p as an Hspec option" do
         splitArgs ["-p"] `shouldBe` ([], ["-p"])
 
-      it "recognizes -pN as an Hspec option" $ do
+      it "recognizes -pN as an Hspec option" do
         splitArgs ["-p20"] `shouldBe` ([], ["-p20"])
 
-      it "recognizes -packageNAME as a GHC option" $ do
+      it "recognizes -packageNAME as a GHC option" do
         splitArgs ["-packagebase"] `shouldBe` (["-packagebase"], [])


### PR DESCRIPTION
Don't accept Hspec's `-f <formatter>`, as it collides with GHC flags. Instead, `--format <formatter>` can be used.